### PR TITLE
Refactoring 2-structured-data tests to use py.test

### DIFF
--- a/2-structured-data/requirements-dev.txt
+++ b/2-structured-data/requirements-dev.txt
@@ -1,8 +1,5 @@
 tox==2.3.1
-unittest2==1.1.0
-nose==1.3.7
 flake8==2.5.4
-coverage==4.1b2
-BeautifulSoup4==4.4.1
-mock==1.3.0
-flaky==3.0.3
+flaky==3.1.0
+pytest==2.8.7
+pytest-cov==2.2.1

--- a/2-structured-data/requirements.txt
+++ b/2-structured-data/requirements.txt
@@ -1,9 +1,9 @@
 Flask==0.10.1
-gcloud==0.9.0
+gcloud==0.10.1
 gunicorn==19.4.5
-oauth2client==1.5.2
+oauth2client==2.0.0.post1
 Flask-SQLAlchemy==2.1
-PyMySQL==0.7.1
+PyMySQL==0.7.2
 Flask-PyMongo==0.4.0
 PyMongo==3.2.1
 six==1.10.0

--- a/2-structured-data/tests/test_crud.py
+++ b/2-structured-data/tests/test_crud.py
@@ -12,67 +12,88 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
 import bookshelf
 import config
 from flaky import flaky
 from gcloud.exceptions import ServiceUnavailable
-from nose.plugins.attrib import attr
+import pytest
+
+
+@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+def app(request):
+    """This fixtures provides a Flask app instance configured for testing.
+
+    Because it's parametric, it will cause every test that uses this fixture
+    to run three times: one time for each backend (datastore, cloudsql, and
+    mongodb).
+
+    It also ensures the tests run within a request context, allowing
+    any calls to flask.request, flask.current_app, etc. to work."""
+    app = bookshelf.create_app(
+        config,
+        testing=True,
+        config_overrides={
+            'DATA_BACKEND': request.param
+        })
+
+    with app.test_request_context():
+        yield app
+
+
+@pytest.yield_fixture
+def model(monkeypatch, app):
+    """This fixture provides a modified version of the app's model that tracks
+    all created items and deletes them at the end of the test.
+
+    Any tests that directly or indirectly interact with the database should use
+    this to ensure that resources are properly cleaned up.
+
+    Monkeypatch is provided by pytest and used to patch the model's create
+    method.
+
+    The app fixture is needed to provide the configuration and context needed
+    to get the proper model object.
+    """
+    model = bookshelf.get_model()
+
+    ids_to_delete = []
+
+    # Monkey-patch create so we can track the IDs of every item
+    # created and delete them after the test case.
+    original_create = model.create
+
+    def tracking_create(*args, **kwargs):
+        res = original_create(*args, **kwargs)
+        ids_to_delete.append(res['id'])
+        return res
+
+    monkeypatch.setattr(model, 'create', tracking_create)
+
+    yield model
+
+    # Delete all items that we created during tests.
+    list(map(model.delete, ids_to_delete))
 
 
 def flaky_filter(e, *args):
+    """Used by flaky to determine when to re-run a test case."""
     return isinstance(e, ServiceUnavailable)
 
 
+# Mark all test cases in this class as flaky, so that if errors occur they
+# can be retried. This is useful when databases are temporarily unavailable.
 @flaky(rerun_filter=flaky_filter)
-class IntegrationBase(unittest.TestCase):
+# Tell pytest to use both the app and model fixtures for all test cases.
+# This ensures that configuration is properly applied and that all database
+# resources created during tests are cleaned up.
+@pytest.mark.usefixtures('app', 'model')
+class TestCrudActions(object):
 
-    def createBooks(self, n=1):
-        with self.app.test_request_context():
-            for i in range(1, n + 1):
-                self.model.create({'title': u'Book {0}'.format(i)})
+    def test_list(self, app, model):
+        for i in range(1, 12):
+            model.create({'title': u'Book {0}'.format(i)})
 
-    def setUp(self):
-        self.app = bookshelf.create_app(
-            config,
-            testing=True,
-            config_overrides={
-                'DATA_BACKEND': self.backend
-            }
-        )
-
-        with self.app.app_context():
-            self.model = bookshelf.get_model()
-
-        self.ids_to_delete = []
-
-        # Monkey-patch create so we can track the IDs of every item
-        # created and delete them during tearDown.
-        self.original_create = self.model.create
-
-        def tracking_create(*args, **kwargs):
-            res = self.original_create(*args, **kwargs)
-            self.ids_to_delete.append(res['id'])
-            return res
-
-        self.model.create = tracking_create
-
-    def tearDown(self):
-
-        # Delete all items that we created during tests.
-        with self.app.test_request_context():
-            list(map(self.model.delete, self.ids_to_delete))
-
-        self.model.create = self.original_create
-
-
-@attr('slow')
-class CrudTestsMixin(object):
-    def testList(self):
-        self.createBooks(11)
-
-        with self.app.test_client() as c:
+        with app.test_client() as c:
             rv = c.get('/books/')
 
         assert rv.status == '200 OK'
@@ -84,7 +105,7 @@ class CrudTestsMixin(object):
         assert 'Book 9' not in body, "Should not show more than 10 books"
         assert 'More' in body, "Should have more than one page"
 
-    def testAddAndView(self):
+    def test_add(self, app):
         data = {
             'title': 'Test Book',
             'author': 'Test Author',
@@ -92,58 +113,37 @@ class CrudTestsMixin(object):
             'description': 'Test Description'
         }
 
-        with self.app.test_client() as c:
+        with app.test_client() as c:
             rv = c.post('/books/add', data=data, follow_redirects=True)
 
         assert rv.status == '200 OK'
-
         body = rv.data.decode('utf-8')
         assert 'Test Book' in body
         assert 'Test Author' in body
         assert 'Test Date Published' in body
         assert 'Test Description' in body
 
-    def testEditAndView(self):
-        with self.app.test_request_context():
-            existing = self.model.create({'title': "Temp Title"})
+    def test_edit(self, app, model):
+        existing = model.create({'title': "Temp Title"})
 
-        with self.app.test_client() as c:
+        with app.test_client() as c:
             rv = c.post(
                 '/books/%s/edit' % existing['id'],
                 data={'title': 'Updated Title'},
                 follow_redirects=True)
 
         assert rv.status == '200 OK'
-
         body = rv.data.decode('utf-8')
         assert 'Updated Title' in body
         assert 'Temp Title' not in body
 
-    def testDelete(self):
-        with self.app.test_request_context():
-            existing = self.model.create({'title': "Temp Title"})
+    def test_delete(self, app, model):
+        existing = model.create({'title': "Temp Title"})
 
-        with self.app.test_client() as c:
+        with app.test_client() as c:
             rv = c.get(
                 '/books/%s/delete' % existing['id'],
                 follow_redirects=True)
 
         assert rv.status == '200 OK'
-
-        with self.app.test_request_context():
-            assert not self.model.read(existing['id'])
-
-
-@attr('datastore')
-class TestDatastore(CrudTestsMixin, IntegrationBase):
-    backend = 'datastore'
-
-
-@attr('cloudsql')
-class TestCloudSql(CrudTestsMixin, IntegrationBase):
-    backend = 'cloudsql'
-
-
-@attr('mongodb')
-class TestMongo(CrudTestsMixin, IntegrationBase):
-    backend = 'mongodb'
+        assert not model.read(existing['id'])

--- a/2-structured-data/tox.ini
+++ b/2-structured-data/tox.ini
@@ -8,13 +8,9 @@ deps =
   -rrequirements.txt
   -rrequirements-dev.txt
 commands =
-  nosetests \
-    --with-flaky \
-    --no-success-flaky-report \
-    --with-coverage \
-    --cover-package bookshelf \
-    {posargs:-a '!e2e'}
+  py.test --cov=bookshelf --no-success-flaky-report {posargs} tests
 passenv = GOOGLE_APPLICATION_CREDENTIALS
+setenv = PYTHONPATH={toxinidir}
 
 [testenv:py34]
 basepython = python3.4


### PR DESCRIPTION
@waprin Note that this is being merged into the `pytest-refactor` branch, which we'll merge into master when all is done.

Also, question for you: I can put all of the test functions in a class and mark the whole class as flaky. That'll keep me from having to mark each test case as flaky. Your call.