### PR TITLE
Fix only show 10 books test

### DIFF
--- a/2-structured-data/tests/test_crud.py
+++ b/2-structured-data/tests/test_crud.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 from conftest import flaky_filter
 from flaky import flaky
 import pytest
@@ -38,9 +40,8 @@ class TestCrudActions(object):
 
         body = rv.data.decode('utf-8')
         assert 'Book 1' in body, "Should show books"
-        # Ordering is lexical, so 9 will be on page two and 10 and 11 will
-        # be after 1.
-        assert 'Book 9' not in body, "Should not show more than 10 books"
+        assert (len(re.findall('<h4>Book', body)) == 10,
+                "Should not show more than 10 books")
         assert 'More' in body, "Should have more than one page"
 
     def test_add(self, app):

--- a/3-binary-data/tests/test_crud.py
+++ b/3-binary-data/tests/test_crud.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 from conftest import flaky_filter
 from flaky import flaky
 import pytest
@@ -38,9 +40,8 @@ class TestCrudActions(object):
 
         body = rv.data.decode('utf-8')
         assert 'Book 1' in body, "Should show books"
-        # Ordering is lexical, so 9 will be on page two and 10 and 11 will
-        # be after 1.
-        assert 'Book 9' not in body, "Should not show more than 10 books"
+        assert (len(re.findall('<h4>Book', body)) == 10,
+                "Should not show more than 10 books")
         assert 'More' in body, "Should have more than one page"
 
     def test_add(self, app):

--- a/4-auth/tests/test_crud.py
+++ b/4-auth/tests/test_crud.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 from conftest import flaky_filter
 from flaky import flaky
 import pytest
@@ -38,9 +40,8 @@ class TestCrudActions(object):
 
         body = rv.data.decode('utf-8')
         assert 'Book 1' in body, "Should show books"
-        # Ordering is lexical, so 9 will be on page two and 10 and 11 will
-        # be after 1.
-        assert 'Book 9' not in body, "Should not show more than 10 books"
+        assert (len(re.findall('<h4>Book', body)) == 10,
+                "Should not show more than 10 books")
         assert 'More' in body, "Should have more than one page"
 
     def test_add(self, app):

--- a/5-logging/tests/test_crud.py
+++ b/5-logging/tests/test_crud.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 from conftest import flaky_filter
 from flaky import flaky
 import pytest
@@ -38,9 +40,8 @@ class TestCrudActions(object):
 
         body = rv.data.decode('utf-8')
         assert 'Book 1' in body, "Should show books"
-        # Ordering is lexical, so 9 will be on page two and 10 and 11 will
-        # be after 1.
-        assert 'Book 9' not in body, "Should not show more than 10 books"
+        assert (len(re.findall('<h4>Book', body)) == 10,
+                "Should not show more than 10 books")
         assert 'More' in body, "Should have more than one page"
 
     def test_add(self, app):

--- a/6-pubsub/tests/test_crud.py
+++ b/6-pubsub/tests/test_crud.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 from conftest import flaky_filter
 from flaky import flaky
 import pytest
@@ -38,9 +40,8 @@ class TestCrudActions(object):
 
         body = rv.data.decode('utf-8')
         assert 'Book 1' in body, "Should show books"
-        # Ordering is lexical, so 9 will be on page two and 10 and 11 will
-        # be after 1.
-        assert 'Book 9' not in body, "Should not show more than 10 books"
+        assert (len(re.findall('<h4>Book', body)) == 10,
+                "Should not show more than 10 books")
         assert 'More' in body, "Should have more than one page"
 
     def test_add(self, app):

--- a/7-gce/tests/test_crud.py
+++ b/7-gce/tests/test_crud.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 from conftest import flaky_filter
 from flaky import flaky
 import pytest
@@ -38,9 +40,8 @@ class TestCrudActions(object):
 
         body = rv.data.decode('utf-8')
         assert 'Book 1' in body, "Should show books"
-        # Ordering is lexical, so 9 will be on page two and 10 and 11 will
-        # be after 1.
-        assert 'Book 9' not in body, "Should not show more than 10 books"
+        assert (len(re.findall('<h4>Book', body)) == 10,
+                "Should not show more than 10 books")
         assert 'More' in body, "Should have more than one page"
 
     def test_add(self, app):

--- a/nox.py
+++ b/nox.py
@@ -3,7 +3,7 @@ import shutil
 
 import nox
 
-REPO_TOOLS_REQ =\
+REPO_TOOLS_REQ = \
     'git+https://github.com/GoogleCloudPlatform/python-repo-tools.git'
 
 DIRS = [
@@ -35,12 +35,22 @@ def session_lint(session):
         '--import-order-style=google', '.')
 
 
-@nox.parametrize('dir', DIRS)
-def session_run_tests(session, dir=None, toxargs=None):
-    """Run all tests for all directories (slow!)"""
+def run_test(session, dir, toxargs):
     shutil.copy('config.py', dir)
     session.chdir(dir)
     session.run('tox', *(toxargs or []))
+
+
+@nox.parametrize('dir', DIRS)
+def session_run_tests(session, dir=None, toxargs=None):
+    """Run all tests for all directories (slow!)"""
+    run_test(session, dir, toxargs)
+
+
+def session_run_one_test(session):
+    dir = session.posargs[0]
+    toxargs = session.posargs[1:]
+    run_test(session, dir, toxargs)
 
 
 @nox.parametrize('dir', DIRS)

--- a/optional-container-engine/tests/test_crud.py
+++ b/optional-container-engine/tests/test_crud.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 from conftest import flaky_filter
 from flaky import flaky
 import pytest
@@ -38,9 +40,8 @@ class TestCrudActions(object):
 
         body = rv.data.decode('utf-8')
         assert 'Book 1' in body, "Should show books"
-        # Ordering is lexical, so 9 will be on page two and 10 and 11 will
-        # be after 1.
-        assert 'Book 9' not in body, "Should not show more than 10 books"
+        assert (len(re.findall('<h4>Book', body)) == 10,
+                "Should not show more than 10 books")
         assert 'More' in body, "Should have more than one page"
 
     def test_add(self, app):


### PR DESCRIPTION
The ordering of the output is unreliable in datstore and cloudsql.

Also add one direction nox sessions to simplify
local testing