### PR TITLE
Changed module to service in pubsub appyaml

### DIFF
--- a/6-pubsub/app.yaml
+++ b/6-pubsub/app.yaml
@@ -21,7 +21,7 @@ env: flex
 
 # [START entrypoint]
 # Instead of using gunicorn directly, we'll use Honcho. Honcho is a python port
-# of the Foreman process manager. For the default module, only the
+# of the Foreman process manager. For the default service, only the
 # frontend process is needed.
 entrypoint: honcho start -f /app/procfile bookshelf
 # [END entrypoint]


### PR DESCRIPTION
As per comments Bookshelf Pub/Sub changelist, I changed "module" to "service" in app.yaml comments because of change in terminology for Pub/Sub.