### PR TITLE
Changed module to service in pubsub workeryaml

### DIFF
--- a/6-pubsub/worker.yaml
+++ b/6-pubsub/worker.yaml
@@ -22,7 +22,7 @@ runtime: python
 env: flex
 
 # Instead of using gunicorn directly, we'll use Honcho. Honcho is a python port
-# of the Foreman process manager. For the worker module, both the queue worker
+# of the Foreman process manager. For the worker service, both the queue worker
 # and the monitor process are needed.
 entrypoint: honcho start -f /app/procfile worker monitor
 


### PR DESCRIPTION
As per comments Bookshelf Pub/Sub changelist, I changed "module" to "service" in worker.yaml comments because of change in terminology for Pub/Sub.