### PR TITLE
Add Stackdriver Error Reporting

### DIFF
--- a/6-pubsub/bookshelf/__init__.py
+++ b/6-pubsub/bookshelf/__init__.py
@@ -16,6 +16,7 @@ import json
 import logging
 
 from flask import current_app, Flask, redirect, request, session, url_for
+from google.cloud import error_reporting
 import google.cloud.logging
 import httplib2
 from oauth2client.contrib.flask_util import UserOAuth2
@@ -68,15 +69,17 @@ def create_app(config, debug=False, testing=False, config_overrides=None):
     def index():
         return redirect(url_for('crud.list'))
 
-    # Add an error handler. This is useful for debugging the live application,
-    # however, you should disable the output of the exception for production
-    # applications.
+    # Add an error handler that reports exceptions to Stackdriver Error
+    # Reporting. Note that this error handler is only used when debug
+    # is False
     @app.errorhandler(500)
     def server_error(e):
+        client = error_reporting.Client(app.config['PROJECT_ID'])
+        client.report_exception(
+            http_context=error_reporting.build_flask_context(request))
         return """
-        An internal error occurred: <pre>{}</pre>
-        See logs for full stacktrace.
-        """.format(e), 500
+        An internal error occurred.
+        """, 500
 
     return app
 

--- a/7-gce/bookshelf/__init__.py
+++ b/7-gce/bookshelf/__init__.py
@@ -16,6 +16,7 @@ import json
 import logging
 
 from flask import current_app, Flask, redirect, request, session, url_for
+from google.cloud import error_reporting
 import google.cloud.logging
 import httplib2
 from oauth2client.contrib.flask_util import UserOAuth2
@@ -77,15 +78,17 @@ def create_app(config, debug=False, testing=False, config_overrides=None):
     def index():
         return redirect(url_for('crud.list'))
 
-    # Add an error handler. This is useful for debugging the live application,
-    # however, you should disable the output of the exception for production
-    # applications.
+    # Add an error handler that reports exceptions to Stackdriver Error
+    # Reporting. Note that this error handler is only used when Debug
+    # is False
     @app.errorhandler(500)
     def server_error(e):
+        client = error_reporting.Client(app.config['PROJECT_ID'])
+        client.report_exception(
+            http_context=error_reporting.build_flask_context(request))
         return """
-        An internal error occurred: <pre>{}</pre>
-        See logs for full stacktrace.
-        """.format(e), 500
+        An internal error occurred.
+        """, 500
 
     return app
 


### PR DESCRIPTION
@jonparrott want to put this somewhere, feel like logging is the easiest?

The old comment was slightly misleading, because it says its "useful for debugging the live application" but in debug mode, errorhandler isn't actually called on 500. 

From [Flask docs](http://flask.pocoo.org/docs/0.11/patterns/errorpages/):

> Please note that if you add an error handler for “500 Internal Server Error”, Flask will not trigger it if it’s running in Debug mode.


So since the code is only ever run when debug is false, there is no reason to give an informative error message. So I think reporting to Error Reporting and returning a generic error message is what we want there.