### PR TITLE
Use bucket() instead of get_bucket()

### DIFF
--- a/3-binary-data/bookshelf/storage.py
+++ b/3-binary-data/bookshelf/storage.py
@@ -58,7 +58,7 @@ def upload_file(file_stream, filename, content_type):
     filename = _safe_filename(filename)
 
     client = _get_storage_client()
-    bucket = client.get_bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
+    bucket = client.bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
     blob = bucket.blob(filename)
 
     blob.upload_from_string(

--- a/4-auth/bookshelf/storage.py
+++ b/4-auth/bookshelf/storage.py
@@ -57,7 +57,7 @@ def upload_file(file_stream, filename, content_type):
     filename = _safe_filename(filename)
 
     client = _get_storage_client()
-    bucket = client.get_bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
+    bucket = client.bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
     blob = bucket.blob(filename)
 
     blob.upload_from_string(

--- a/5-logging/bookshelf/storage.py
+++ b/5-logging/bookshelf/storage.py
@@ -57,7 +57,7 @@ def upload_file(file_stream, filename, content_type):
     filename = _safe_filename(filename)
 
     client = _get_storage_client()
-    bucket = client.get_bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
+    bucket = client.bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
     blob = bucket.blob(filename)
 
     blob.upload_from_string(

--- a/6-pubsub/bookshelf/storage.py
+++ b/6-pubsub/bookshelf/storage.py
@@ -57,7 +57,7 @@ def upload_file(file_stream, filename, content_type):
     filename = _safe_filename(filename)
 
     client = _get_storage_client()
-    bucket = client.get_bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
+    bucket = client.bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
     blob = bucket.blob(filename)
 
     blob.upload_from_string(

--- a/7-gce/bookshelf/storage.py
+++ b/7-gce/bookshelf/storage.py
@@ -57,7 +57,7 @@ def upload_file(file_stream, filename, content_type):
     filename = _safe_filename(filename)
 
     client = _get_storage_client()
-    bucket = client.get_bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
+    bucket = client.bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
     blob = bucket.blob(filename)
 
     blob.upload_from_string(

--- a/optional-container-engine/bookshelf/storage.py
+++ b/optional-container-engine/bookshelf/storage.py
@@ -57,7 +57,7 @@ def upload_file(file_stream, filename, content_type):
     filename = _safe_filename(filename)
 
     client = _get_storage_client()
-    bucket = client.get_bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
+    bucket = client.bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
     blob = bucket.blob(filename)
 
     blob.upload_from_string(


### PR DESCRIPTION
This avoids an unnecessary request, and means that the client will work
when using the default "Storage Object Creator" role for a Cloud service
account.

I've tested it as part of our (internal) codebase, but I haven't tested this as part of the bookshelf app. I couldn't get the tests in nox.py to work - are there instructions on how to run these?