### PR TITLE
Add support to delete book image files when a book entry is deleted.

### DIFF
--- a/7-gce/bookshelf/crud.py
+++ b/7-gce/bookshelf/crud.py
@@ -127,5 +127,12 @@ def edit(id):
 
 @crud.route('/<id>/delete')
 def delete(id):
+    book = get_model().read(id)
+    image_url = book.get('imageUrl')
     get_model().delete(id)
+    # async job to delete book image in GCS
+    if image_url:
+        image_name = image_url.split('/')[-1]
+        q = tasks.get_books_queue()
+        q.enqueue(tasks.delete_book_image, image_name)
     return redirect(url_for('.list'))

--- a/7-gce/bookshelf/storage.py
+++ b/7-gce/bookshelf/storage.py
@@ -70,3 +70,14 @@ def upload_file(file_stream, filename, content_type):
         url = url.decode('utf-8')
 
     return url
+
+
+def delete_file(blob_name):
+    """
+    Deletes a file from a given Google Cloud Storage bucket
+    """
+    client = _get_storage_client()
+    bucket = client.get_bucket(current_app.config['CLOUD_STORAGE_BUCKET'])
+    blob = bucket.blob(blob_name)
+    blob.delete()
+    return blob.name

--- a/7-gce/bookshelf/tasks.py
+++ b/7-gce/bookshelf/tasks.py
@@ -115,3 +115,10 @@ def download_and_upload_image(src, dst_filename):
         r.content,
         dst_filename,
         r.headers.get('content-type', 'image/jpeg'))
+
+def delete_book_image(blob_name):
+    """
+    Deletes an image file from Google Cloud Storage.
+    """
+    logging.info("Deleting book image {} from storage bucket.".format(blob_name))
+    return storage.delete_file(blob_name)


### PR DESCRIPTION
Delete book images from Google cloud storage when a book entry is deleted. 

Current app keeps images of deleted books in storage bucket, and if the same book is removed and added back again, multiple identical image files remain in storage.