### PR TITLE
Use the right gcloud argument

### DIFF
--- a/optional-container-engine/Makefile
+++ b/optional-container-engine/Makefile
@@ -6,7 +6,7 @@ all: deploy
 .PHONY: create-cluster
 create-cluster:
 	gcloud container clusters create bookshelf \
-		--scope "cloud-platform" \
+		--scopes "cloud-platform" \
 		--num-nodes 2
 	gcloud container clusters get-credentials bookshelf
 


### PR DESCRIPTION
Using --scopes instead of --scope (scope doesn't exist according to https://cloud.google.com/sdk/gcloud/reference/container/clusters/create verified with the gcloud utility as well)