### PR TITLE
[reqs] add oauth2client to 2-structured-data which is required

### DIFF
--- a/2-structured-data/requirements.txt
+++ b/2-structured-data/requirements.txt
@@ -1,6 +1,7 @@
 Flask==0.12.2
 google-cloud-datastore==1.4.0
 gunicorn==19.7.1
+oauth2client==4.1.2
 Flask-SQLAlchemy==2.3.2
 PyMySQL==0.8.0
 Flask-PyMongo==0.5.1


### PR DESCRIPTION
Tests are currently failing: https://travis-ci.org/GoogleCloudPlatform/getting-started-python

Error:
```
ImportError: No module named 'oauth2client'
ERROR: could not load /home/travis/build/GoogleCloudPlatform/getting-started-python/2-structured-data/tests/conftest.py
```

This adds `oauth2client` to `requirements.txt` and should rectify the issue.