### PR TITLE
SQLALCHEMY shouldn't be connecting to localhost when running on live

### DIFF
--- a/2-structured-data/config.py
+++ b/2-structured-data/config.py
@@ -62,7 +62,7 @@ LOCAL_SQLALCHEMY_DATABASE_URI = (
 # When running on App Engine a unix socket is used to connect to the cloudsql
 # instance.
 LIVE_SQLALCHEMY_DATABASE_URI = (
-    'mysql+pymysql://{user}:{password}@localhost/{database}'
+    'mysql+pymysql://{user}:{password}@/{database}'
     '?unix_socket=/cloudsql/{connection_name}').format(
         user=CLOUDSQL_USER, password=CLOUDSQL_PASSWORD,
         database=CLOUDSQL_DATABASE, connection_name=CLOUDSQL_CONNECTION_NAME)

--- a/3-binary-data/config.py
+++ b/3-binary-data/config.py
@@ -62,7 +62,7 @@ LOCAL_SQLALCHEMY_DATABASE_URI = (
 # When running on App Engine a unix socket is used to connect to the cloudsql
 # instance.
 LIVE_SQLALCHEMY_DATABASE_URI = (
-    'mysql+pymysql://{user}:{password}@localhost/{database}'
+    'mysql+pymysql://{user}:{password}@/{database}'
     '?unix_socket=/cloudsql/{connection_name}').format(
         user=CLOUDSQL_USER, password=CLOUDSQL_PASSWORD,
         database=CLOUDSQL_DATABASE, connection_name=CLOUDSQL_CONNECTION_NAME)

--- a/4-auth/config.py
+++ b/4-auth/config.py
@@ -64,7 +64,7 @@ LOCAL_SQLALCHEMY_DATABASE_URI = (
 # When running on App Engine a unix socket is used to connect to the cloudsql
 # instance.
 LIVE_SQLALCHEMY_DATABASE_URI = (
-    'mysql+pymysql://{user}:{password}@localhost/{database}'
+    'mysql+pymysql://{user}:{password}@/{database}'
     '?unix_socket=/cloudsql/{connection_name}').format(
         user=CLOUDSQL_USER, password=CLOUDSQL_PASSWORD,
         database=CLOUDSQL_DATABASE, connection_name=CLOUDSQL_CONNECTION_NAME)

--- a/5-logging/config.py
+++ b/5-logging/config.py
@@ -62,7 +62,7 @@ LOCAL_SQLALCHEMY_DATABASE_URI = (
 # When running on App Engine a unix socket is used to connect to the cloudsql
 # instance.
 LIVE_SQLALCHEMY_DATABASE_URI = (
-    'mysql+pymysql://{user}:{password}@localhost/{database}'
+    'mysql+pymysql://{user}:{password}@/{database}'
     '?unix_socket=/cloudsql/{connection_name}').format(
         user=CLOUDSQL_USER, password=CLOUDSQL_PASSWORD,
         database=CLOUDSQL_DATABASE, connection_name=CLOUDSQL_CONNECTION_NAME)

--- a/6-pubsub/config.py
+++ b/6-pubsub/config.py
@@ -65,7 +65,7 @@ LOCAL_SQLALCHEMY_DATABASE_URI = (
 # When running on App Engine a unix socket is used to connect to the cloudsql
 # instance.
 LIVE_SQLALCHEMY_DATABASE_URI = (
-    'mysql+pymysql://{user}:{password}@localhost/{database}'
+    'mysql+pymysql://{user}:{password}@/{database}'
     '?unix_socket=/cloudsql/{connection_name}').format(
         user=CLOUDSQL_USER, password=CLOUDSQL_PASSWORD,
         database=CLOUDSQL_DATABASE, connection_name=CLOUDSQL_CONNECTION_NAME)

--- a/7-gce/config.py
+++ b/7-gce/config.py
@@ -62,7 +62,7 @@ LOCAL_SQLALCHEMY_DATABASE_URI = (
 # When running on App Engine a unix socket is used to connect to the cloudsql
 # instance.
 LIVE_SQLALCHEMY_DATABASE_URI = (
-    'mysql+pymysql://{user}:{password}@localhost/{database}'
+    'mysql+pymysql://{user}:{password}@/{database}'
     '?unix_socket=/cloudsql/{connection_name}').format(
         user=CLOUDSQL_USER, password=CLOUDSQL_PASSWORD,
         database=CLOUDSQL_DATABASE, connection_name=CLOUDSQL_CONNECTION_NAME)

--- a/optional-kubernetes-engine/config.py
+++ b/optional-kubernetes-engine/config.py
@@ -59,7 +59,7 @@ LOCAL_SQLALCHEMY_DATABASE_URI = (
 # When running on App Engine a unix socket is used to connect to the cloudsql
 # instance.
 LIVE_SQLALCHEMY_DATABASE_URI = (
-    'mysql+pymysql://{user}:{password}@localhost/{database}'
+    'mysql+pymysql://{user}:{password}@/{database}'
     '?unix_socket=/cloudsql/{connection_name}').format(
         user=CLOUDSQL_USER, password=CLOUDSQL_PASSWORD,
         database=CLOUDSQL_DATABASE, connection_name=CLOUDSQL_CONNECTION_NAME)


### PR DESCRIPTION
I was getting this error:

`Can't connect to MySQL server on 'localhost' ([Errno 2] No such file or directory)`

So I looked up the correct usage in the [using clouds-sql documentation](https://cloud.google.com/appengine/docs/flexible/python/using-cloud-sql)

refs #129