### PR TITLE
Fix Python Bookshelf for GCE.

### DIFF
--- a/6-pubsub/requirements.txt
+++ b/6-pubsub/requirements.txt
@@ -12,4 +12,4 @@ PyMongo==3.6.0
 six==1.11.0
 requests[security]==2.18.4
 honcho==1.0.1
-psq==0.6.0
+psq==0.7.0

--- a/7-gce/bookshelf/templates/base.html
+++ b/7-gce/bookshelf/templates/base.html
@@ -29,20 +29,7 @@
         </div>
         <ul class="nav navbar-nav">
           <li><a href="/books">Books</a></li>
-          <li><a href="/books/mine">My Books</a></li>
         </ul>
-        <p class="navbar-text navbar-right">
-        {% if session.profile %}
-          <a href="/logout">
-            {% if session.profile.image %}
-              <img class="img-circle" src="{{session.profile.image.url}}" width="24">
-            {% endif %}
-            {{session.profile.displayName}}
-          </a>
-        {% else %}
-          <a href="/oauth2authorize">Login</a>
-        {% endif %}
-        </p>
       </div>
     </div>
     <div class="container">

--- a/7-gce/gce/deploy.sh
+++ b/7-gce/gce/deploy.sh
@@ -20,7 +20,7 @@ ZONE=us-central1-f
 GROUP=frontend-group
 TEMPLATE=$GROUP-tmpl
 MACHINE_TYPE=f1-micro
-IMAGE_FAMILY=debian-8
+IMAGE_FAMILY=debian-9
 IMAGE_PROJECT=debian-cloud
 STARTUP_SCRIPT=startup-script.sh
 SCOPES="userinfo-email,cloud-platform"
@@ -30,7 +30,7 @@ MIN_INSTANCES=1
 MAX_INSTANCES=10
 TARGET_UTILIZATION=0.6
 
-SERVICE=frontend-web-service
+SERVICE=my-app-service
 
 #
 # Instance group setup
@@ -58,7 +58,7 @@ gcloud compute instance-groups managed \
   --base-instance-name $GROUP \
   --size $MIN_INSTANCES \
   --template $TEMPLATE \
-  --zone $ZONE 
+  --zone $ZONE
 # [END create_group]
 
 # [START create_named_port]
@@ -140,7 +140,7 @@ gcloud compute instance-groups managed set-autoscaling \
   $GROUP \
   --max-num-replicas $MAX_INSTANCES \
   --target-load-balancing-utilization $TARGET_UTILIZATION \
-  --zone $ZONE 
+  --zone $ZONE
 # [END set_autoscaling]
 
 # [START create_firewall]
@@ -153,7 +153,7 @@ else
     --allow tcp:8080 \
     --source-ranges 0.0.0.0/0 \
     --target-tags http-server \
-    --description "Allow port 8080 access to http-server" 
+    --description "Allow port 8080 access to http-server"
 fi
 
 # [END create_firewall]

--- a/7-gce/gce/deployment_manager/config.yaml
+++ b/7-gce/gce/deployment_manager/config.yaml
@@ -23,7 +23,7 @@ resources:
   properties:
     zone: us-central1-f
     machine-type: n1-standard-1
-    machine-image: https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-8
+    machine-image: https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9
     min-instances: 1
     max-instances: 10
     target-utilization: 0.6

--- a/7-gce/gce/startup-script.sh
+++ b/7-gce/gce/startup-script.sh
@@ -45,7 +45,8 @@ git config --global credential.helper gcloud.sh
 git clone https://source.developers.google.com/p/$PROJECTID/r/[YOUR_REPO_NAME] /opt/app
 
 # Install app dependencies
-virtualenv /opt/app/7-gce/env
+virtualenv -p python3 /opt/app/7-gce/env
+source /opt/app/7-gce/env/bin/activate
 /opt/app/7-gce/env/bin/pip install -r /opt/app/7-gce/requirements.txt
 
 # Make sure the pythonapp user owns the application code
@@ -56,13 +57,13 @@ chown -R pythonapp:pythonapp /opt/app
 cat >/etc/supervisor/conf.d/python-app.conf << EOF
 [program:pythonapp]
 directory=/opt/app/7-gce
-command=/opt/app/7-gce/env/bin/gunicorn main:app --bind 0.0.0.0:8080
+command=/opt/app/7-gce/env/bin/honcho start -f ./procfile worker bookshelf
 autostart=true
 autorestart=true
 user=pythonapp
 # Environment variables ensure that the application runs inside of the
 # configured virtualenv.
-environment=VIRTUAL_ENV="/opt/app/env/7-gce",PATH="/opt/app/7-gce/env/bin",\
+environment=VIRTUAL_ENV="/opt/app/7-gce/env",PATH="/opt/app/7-gce/env/bin",\
     HOME="/home/pythonapp",USER="pythonapp"
 stdout_logfile=syslog
 stderr_logfile=syslog

--- a/7-gce/gce/teardown.sh
+++ b/7-gce/gce/teardown.sh
@@ -20,7 +20,7 @@ gcloud config set compute/zone $ZONE
 
 GROUP=frontend-group
 TEMPLATE=$GROUP-tmpl
-SERVICE=frontend-web-service
+SERVICE=my-app-service
 
 gcloud compute instance-groups managed stop-autoscaling $GROUP --zone $ZONE
 

--- a/7-gce/procfile
+++ b/7-gce/procfile
@@ -1,3 +1,3 @@
-bookshelf: gunicorn -b 0.0.0.0:$PORT main:app
+bookshelf: gunicorn -b 0.0.0.0:8080 main:app
 worker: psqworker --pid /tmp/psq.pid main.books_queue
 monitor: python monitor.py /tmp/psq.pid

--- a/7-gce/requirements.txt
+++ b/7-gce/requirements.txt
@@ -12,4 +12,4 @@ PyMongo==3.6.0
 six==1.11.0
 requests[security]==2.18.4
 honcho==1.0.1
-psq==0.6.0
+psq==0.7.0

--- a/optional-kubernetes-engine/bookshelf/templates/base.html
+++ b/optional-kubernetes-engine/bookshelf/templates/base.html
@@ -29,20 +29,7 @@
         </div>
         <ul class="nav navbar-nav">
           <li><a href="/books">Books</a></li>
-          <li><a href="/books/mine">My Books</a></li>
         </ul>
-        <p class="navbar-text navbar-right">
-        {% if session.profile %}
-          <a href="/logout">
-            {% if session.profile.image %}
-              <img class="img-circle" src="{{session.profile.image.url}}" width="24">
-            {% endif %}
-            {{session.profile.displayName}}
-          </a>
-        {% else %}
-          <a href="/oauth2authorize">Login</a>
-        {% endif %}
-        </p>
       </div>
     </div>
     <div class="container">

--- a/optional-kubernetes-engine/requirements.txt
+++ b/optional-kubernetes-engine/requirements.txt
@@ -13,4 +13,4 @@ PyMongo==3.6.0
 six==1.11.0
 requests[security]==2.18.4
 honcho==1.0.1
-psq==0.6.0
+psq==0.7.0


### PR DESCRIPTION
Update to coordinate proper version of psq. Avoid use of authenticated features (My Books) since cannot authenticate when hosting via a vip (like we do in GCE and K8s examples).
Fixes https://github.com/GoogleCloudPlatform/getting-started-python/issues/161