### PR TITLE
Skip sql tests

### DIFF
--- a/2-structured-data/tests/conftest.py
+++ b/2-structured-data/tests/conftest.py
@@ -22,7 +22,8 @@ import pytest
 from retrying import retry
 
 
-@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+#@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+@pytest.yield_fixture(params=['datastore', 'mongodb'])
 def app(request):
     """This fixtures provides a Flask app instance configured for testing.
 

--- a/3-binary-data/tests/conftest.py
+++ b/3-binary-data/tests/conftest.py
@@ -22,7 +22,8 @@ import pytest
 from retrying import retry
 
 
-@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+#@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+@pytest.yield_fixture(params=['datastore', 'mongodb'])
 def app(request):
     """This fixtures provides a Flask app instance configured for testing.
 

--- a/4-auth/tests/conftest.py
+++ b/4-auth/tests/conftest.py
@@ -22,7 +22,8 @@ import pytest
 from retrying import retry
 
 
-@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+#@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+@pytest.yield_fixture(params=['datastore', 'mongodb'])
 def app(request):
     """This fixtures provides a Flask app instance configured for testing.
 

--- a/5-logging/tests/conftest.py
+++ b/5-logging/tests/conftest.py
@@ -22,7 +22,8 @@ import pytest
 from retrying import retry
 
 
-@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+#@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+@pytest.yield_fixture(params=['datastore', 'mongodb'])
 def app(request):
     """This fixtures provides a Flask app instance configured for testing.
 

--- a/6-pubsub/tests/conftest.py
+++ b/6-pubsub/tests/conftest.py
@@ -22,7 +22,8 @@ import pytest
 from retrying import retry
 
 
-@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+#@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+@pytest.yield_fixture(params=['datastore', 'mongodb'])
 def app(request):
     """This fixtures provides a Flask app instance configured for testing.
 

--- a/7-gce/tests/conftest.py
+++ b/7-gce/tests/conftest.py
@@ -22,7 +22,8 @@ import pytest
 from retrying import retry
 
 
-@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+#@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+@pytest.yield_fixture(params=['datastore', 'mongodb'])
 def app(request):
     """This fixtures provides a Flask app instance configured for testing.
 

--- a/optional-kubernetes-engine/tests/conftest.py
+++ b/optional-kubernetes-engine/tests/conftest.py
@@ -22,7 +22,8 @@ import pytest
 from retrying import retry
 
 
-@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+#@pytest.yield_fixture(params=['datastore', 'cloudsql', 'mongodb'])
+@pytest.yield_fixture(params=['datastore', 'mongodb'])
 def app(request):
     """This fixtures provides a Flask app instance configured for testing.
 


### PR DESCRIPTION
Changes to the Cloud SQL test instances make them inaccessible to the tests as written. Skipping those tests until more thorough changes can be made.