### PR TITLE
Update requirements to allow newer six versions.

### DIFF
--- a/bookshelf/requirements.txt
+++ b/bookshelf/requirements.txt
@@ -4,4 +4,4 @@ google-cloud-storage==1.23.0
 google-cloud-logging==1.14.0
 google-cloud-error-reporting==0.33.0
 gunicorn==19.9.0
-six==1.11.0
+six>=1.11.0


### PR DESCRIPTION
Due to a tensorflow dependency in cloud shell, you cannot use bookshelf from the cloudshell without allowing newer versions of six.