### PR TITLE
testing: use secret manager

### DIFF
--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -20,3 +20,9 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: ".kokoro/system_tests.sh"
 }
+
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -20,9 +20,3 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: ".kokoro/system_tests.sh"
 }
-
-# We still rely on the legacy service account.
-env_vars: {
-    key: "TRAMPOLINE_USE_LEGACY_SERVICE_ACCOUNT"
-    value: "true"
-}

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -12,7 +12,7 @@ build_file: "getting-started-python/.kokoro/trampoline_v2.sh"
 # Use the Python worker docker iamge.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/python@sha256:4b6ba8c199e96248980db4538065cddeea594138b9b9fb2d0388603922087747"
+    value: "gcr.io/cloud-devrel-kokoro-resources/python/getting-started-python"
 }
 
 # Tell the trampoline which build file to use.

--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/cloud-devrel-kokoro-resources/python-base:latest
+
+# Install libraries needed by third-party python packages that we depend on.
+RUN apt update \
+  && apt install -y \
+    graphviz \
+    libcurl4-openssl-dev \
+    libffi-dev \
+    libjpeg-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libmysqlclient-dev \
+    libpng12-dev \
+    libpq-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    openssl \
+    portaudio19-dev \
+    python-pyaudio \
+    zlib1g-dev \
+ && apt clean
+
+RUN python --version
+RUN which python
+
+# Setup Cloud SDK
+ENV CLOUD_SDK_VERSION 315.0.0
+# Use system python for cloud sdk.
+ENV CLOUDSDK_PYTHON /usr/bin/python
+RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz
+RUN tar xzf google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz
+RUN /google-cloud-sdk/install.sh
+ENV PATH /google-cloud-sdk/bin:$PATH
+
+# Setup the user profile for pip
+ENV PATH ~/.local/bin:/root/.local/bin:$PATH
+
+# Install the current version of nox.
+RUN python3 -m pip install --user --no-cache-dir nox==2020.8.22
+
+CMD ["nox"]

--- a/.kokoro/system_tests.cfg
+++ b/.kokoro/system_tests.cfg
@@ -1,0 +1,5 @@
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}

--- a/.kokoro/system_tests.cfg
+++ b/.kokoro/system_tests.cfg
@@ -1,5 +1,0 @@
-# Upload the docker image after successful builds.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE_UPLOAD"
-    value: "true"
-}

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -1,0 +1,50 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Add required env vars here.
+required_envvars+=(
+)
+
+# Add env vars which are passed down into the container here.
+pass_down_envvars+=(
+    # We test this envvar in tests/python/test_envvar.py.
+    "TEST_ENV"
+)
+
+# Prevent unintentional override on the default image.
+if [[ "${TRAMPOLINE_IMAGE_UPLOAD:-false}" == "true" ]] && \
+   [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
+   echo "Please set TRAMPOLINE_IMAGE if you want to upload the Docker image."
+   exit 1
+fi
+
+# Define the default value if it makes sense.
+if [[ -z "${TRAMPOLINE_IMAGE_UPLOAD:-}" ]]; then
+    TRAMPOLINE_IMAGE_UPLOAD=""
+fi
+
+if [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
+    TRAMPOLINE_IMAGE=""
+fi
+
+if [[ -z "${TRAMPOLINE_DOCKERFILE:-}" ]]; then
+    TRAMPOLINE_DOCKERFILE=".kokoro/docker/Dockerfile"
+fi
+
+if [[ -z "${TRAMPOLINE_BUILD_FILE:-}" ]]; then
+    TRAMPOLINE_BUILD_FILE=""
+fi
+
+# The build will show some commands and docker build logs.
+TRAMPOLINE_VERBOSE="true"

--- a/encrypt-secrets.sh
+++ b/encrypt-secrets.sh
@@ -14,9 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-read -s -p "Enter password for encryption: " password
-echo
+set -euo pipefail
 
-tar cvf secrets.tar service-account.json
-openssl aes-256-cbc -k "$password" -in secrets.tar -out secrets.tar.enc
-rm secrets.tar
+# Always cd to the project root.
+readonly root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd ${root}
+
+# Use SECRET_MANAGER_PROJECT if set, fallback to cloud-devrel-kokoro-resources.
+readonly project_id="${SECRET_MANAGER_PROJECT:-cloud-devrel-kokoro-resources}"
+
+gcloud secrets versions add "getting-started-python-service-account" \
+       --project="${project_id}" \
+       --data-file="service-account.json"


### PR DESCRIPTION
We also moved to python-ubuntu pool so that we don't need the legacy
service account any more.