### PR TITLE
fix(bookshelf): explicitly make the uploaded image publicly readable

### DIFF
--- a/bookshelf/storage.py
+++ b/bookshelf/storage.py
@@ -63,6 +63,8 @@ def upload_file(file_stream, filename, content_type):
     blob.upload_from_string(
         file_stream,
         content_type=content_type)
+    # Ensure the file is publicly readable.
+    blob.make_public()
 
     url = blob.public_url
     # [END bookshelf_cloud_storage_client]


### PR DESCRIPTION
I also removed `allUser:Storage.viewer` permission from the testing
bucket.