### PR TITLE
chore: add sync-repo-settings config

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,0 +1,40 @@
+# Whether or not rebase-merging is enabled on this repository.
+# Defaults to `true`
+rebaseMergeAllowed: true
+
+# Whether or not squash-merging is enabled on this repository.
+# Defaults to `true`
+squashMergeAllowed: true
+
+# Whether or not PRs are merged with a merge commit on this repository.
+# Defaults to `false`
+mergeCommitAllowed: false
+
+# Rules for master branch protection
+branchProtectionRules:
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `master`
+- pattern: main
+  # Can admins overwrite branch protection.
+  # Defaults to `true`
+  isAdminEnforced: false
+  # Number of approving reviews required to update matching branches.
+  # Defaults to `1`
+  requiredApprovingReviewCount: 1
+  # Are reviews from code owners required to update matching branches.
+  # Defaults to `false`
+  requiresCodeOwnerReviews: true
+  # Require up to date branches
+  requiresStrictStatusChecks: true
+  # List of required status check contexts that must pass for commits to be accepted to matching branches.
+  requiredStatusCheckContexts:
+    - "kokoro"
+    - "cla/google"
+# List of explicit permissions to add (additive only)
+permissionRules:
+    # Team slug to add to repository permissions
+  - team: yoshi-admins
+    # Access level required, one of push|pull|admin
+    permission: admin
+  - team: python-samples-owners
+    permission: admin


### PR DESCRIPTION
In pursuit of cleaning up config debt, trying to push these configs out to individual repos.  This applies the same settings that are already set - just keeps them in source control and up to date.