### PR TITLE
chore(deps): pin google-cloud-logging version

### DIFF
--- a/bookshelf/requirements.txt
+++ b/bookshelf/requirements.txt
@@ -1,7 +1,7 @@
 Flask==2.0.1
 google-cloud-firestore==2.1.1
 google-cloud-storage==1.38.0
-google-cloud-logging==2.4.0
+google-cloud-logging==2.3.1 #DO NOT UPGRADE: google-cloud-error-reporting 1.1.2 requires google-cloud-logging<2.4,>=1.14.0
 google-cloud-error-reporting==1.1.2
 gunicorn==20.1.0
 six==1.16.0


### PR DESCRIPTION
There is a dependency conflict between `google-cloud-error-reporting` and `google-cloud-logging`. Downgrading `google-cloud-logging` and adding a note for future PRs.

Fixes #357 