### PR TITLE
chore: move Renovate config to .github/, turn off dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+  "extends": [
+    "config:base",
+    ":preserveSemverRanges",
+    ":disableDependencyDashboard"
+  ],
+  "ignorePaths": [
+    "optional-kubernetes-engine"
+  ]
+}


### PR DESCRIPTION
The [dependency dashboard](https://github.com/GoogleCloudPlatform/getting-started-python/issues/388) was automatically opted in, which we don't need.

Happy to keep it open if anyone wants to leave it open!