### PR TITLE
fix: Kokoro builds with missing pyaudio package

### DIFF
--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -31,7 +31,7 @@ RUN apt update \
     libxslt1-dev \
     openssl \
     portaudio19-dev \
-    python-pyaudio \
+    python3-pyaudio \
     zlib1g-dev \
  && apt clean
 

--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -32,6 +32,7 @@ RUN apt update \
     openssl \
     portaudio19-dev \
     zlib1g-dev \
+    build-essential \
  && apt clean
 
 ###################### Install python 3.12.2

--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -31,20 +31,19 @@ RUN apt update \
     libxslt1-dev \
     openssl \
     portaudio19-dev \
-    python3-pyaudio \
     zlib1g-dev \
  && apt clean
 
-###################### Install python 3.7.12
+###################### Install python 3.12.2
 
-# Download python 3.7.12
-RUN wget https://www.python.org/ftp/python/3.7.12/Python-3.7.12.tgz
+# Download python 3.12.2
+RUN wget https://www.python.org/ftp/python/3.12.2/Python-3.12.2.tgz
 
 # Extract files
-RUN tar -xvf Python-3.7.12.tgz
+RUN tar -xvf Python-3.12.2.tgz
 
-# Install python 3.7.12
-RUN ./Python-3.7.12/configure --enable-optimizations
+# Install python 3.12.2
+RUN ./Python-3.12.2/configure --enable-optimizations
 RUN make altinstall
 
 ###################### Check python version
@@ -53,7 +52,7 @@ RUN python --version
 RUN which python
 
 # Setup Cloud SDK
-ENV CLOUD_SDK_VERSION 369.0.0
+ENV CLOUD_SDK_VERSION 464.0.0
 # Use system python for cloud sdk.
 ENV CLOUDSDK_PYTHON /usr/bin/python
 RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz
@@ -64,7 +63,12 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 # Setup the user profile for pip
 ENV PATH ~/.local/bin:/root/.local/bin:$PATH
 
+# Install the current version of pyaudio.
+RUN python3 -m pip install --user --no-cache-dir pyaudio
+
 # Install the current version of nox.
 RUN python3 -m pip install --user --no-cache-dir nox==2022.1.7
+
+
 
 CMD ["nox"]


### PR DESCRIPTION
An attempt to fix failing Kokoro builds due to `E: Unable to locate package python-pyaudio
` error.

Note: I am not 100% sure if we need `portaudio19-dev` and `python3-pyaudio` at all as I couldn't find any references to these libraries in the source code.