### PR TITLE
Replace python-jose with google alternative

### DIFF
--- a/authenticating-users/main.py
+++ b/authenticating-users/main.py
@@ -18,26 +18,7 @@ import sys
 from flask import Flask
 app = Flask(__name__)
 
-CERTS = None
 AUDIENCE = None
-
-
-# [START getting_started_auth_certs]
-def certs():
-    """Returns a dictionary of current Google public key certificates for
-    validating Google-signed JWTs. Since these change rarely, the result
-    is cached on first request for faster subsequent responses.
-    """
-    import requests
-
-    global CERTS
-    if CERTS is None:
-        response = requests.get(
-            'https://www.gstatic.com/iap/verify/public_key'
-        )
-        CERTS = response.json()
-    return CERTS
-# [END getting_started_auth_certs]
 
 
 # [START getting_started_auth_metadata]
@@ -77,26 +58,29 @@ def audience():
 # [END getting_started_auth_audience]
 
 
-# [START getting_started_auth_validate_assertion]
-def validate_assertion(assertion):
+# [START iap_validate_jwt]
+def validate_iap_jwt(iap_jwt) -> tuple[str, str]:
     """Checks that the JWT assertion is valid (properly signed, for the
     correct audience) and if so, returns strings for the requesting user's
     email and a persistent user ID. If not valid, returns None for each field.
+
+    Source: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/iap/validate_jwt.py
     """
-    from jose import jwt
+    from google.auth.transport import requests as google_auth_requests
+    from google.oauth2 import id_token
 
     try:
-        info = jwt.decode(
-            assertion,
-            certs(),
-            algorithms=['ES256'],
-            audience=audience()
-            )
-        return info['email'], info['sub']
+        decoded_jwt = id_token.verify_token(
+            iap_jwt,
+            google_auth_requests.Request(),
+            audience=audience(),
+            certs_url="https://www.gstatic.com/iap/verify/public_key",
+        )
+        return decoded_jwt["email"], decoded_jwt["sub"]
     except Exception as e:
         print('Failed to validate assertion: {}'.format(e), file=sys.stderr)
         return None, None
-# [END getting_started_auth_validate_assertion]
+# [END iap_validate_jwt]
 
 
 # [START getting_started_auth_front_controller]
@@ -105,7 +89,7 @@ def say_hello():
     from flask import request
 
     assertion = request.headers.get('X-Goog-IAP-JWT-Assertion')
-    email, id = validate_assertion(assertion)
+    email, id = validate_iap_jwt(assertion)
     page = "<h1>Hello {}</h1>".format(email)
     return page
 # [END getting_started_auth_front_controller]

--- a/authenticating-users/main_test.py
+++ b/authenticating-users/main_test.py
@@ -22,7 +22,7 @@ def fake_validate(assertion):
         return None, None
 
 
-main.validate_assertion = fake_validate
+main.validate_iap_jwt = fake_validate
 
 
 def test_home_page():

--- a/authenticating-users/requirements.txt
+++ b/authenticating-users/requirements.txt
@@ -1,6 +1,7 @@
 # [START getting_started_requirements]
 Flask==2.2.5
 cryptography==41.0.2
-python-jose[cryptography]==3.3.0
+google-auth~=2.19.1
+google-cloud-iam~=2.3.0
 requests==2.31.0
 # [END getting_started_requirements]


### PR DESCRIPTION
Closes #565

For more context to why python-jose should be replaced, please reference #565 

This solution is a modified version of another repository of GoogleCloudPlatform: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/iap/validate_jwt.py. Although the code was modified as to minimize the amount of changes necessary in this repository.

The `certs()` method and `CERTS` global have been replaced by a `certs_url` parameter in the `verify_token` method. This did not change behaviour in the tests.