### PR TITLE
[debian] replaced apt-key with more modern approach

### DIFF
--- a/gce/add-google-cloud-ops-agent-repo.sh
+++ b/gce/add-google-cloud-ops-agent-repo.sh
@@ -214,7 +214,7 @@ handle_debian() {
       echo "Adding agent repository for ${ID}."
       ${DRY_RUN} tee <<<"${REPO_DATA}" /etc/apt/sources.list.d/google-cloud-ops-agent.list
       ${DRY_RUN} curl --connect-timeout 5 -s -f "https://${REPO_HOST}/apt/doc/apt-key.gpg" \
-        | ${DRY_RUN} gpg --dearmor -o "${kr_path}"
+        | ${DRY_RUN} gpg --no-default-keyring --keyring "${kr_path}"
       CHANGED=1
     fi
   }

--- a/gce/add-google-cloud-ops-agent-repo.sh
+++ b/gce/add-google-cloud-ops-agent-repo.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# Copyright 2020,2024 Google, LLC and contributors ; All rights reserved.
+# Copyright 2020 Google LLC and contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an "AS-IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.

--- a/gce/add-google-cloud-ops-agent-repo.sh
+++ b/gce/add-google-cloud-ops-agent-repo.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020 Google Inc. All rights reserved.
+# Copyright 2020,2024 Google, LLC and contributors ; All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -207,13 +207,14 @@ handle_debian() {
       ${DRY_RUN} apt-get update; ${DRY_RUN} apt-get -y install ca-certificates; CHANGED=1;
     }
     local CODENAME="${REPO_CODENAME:-"$(lsb_release -sc)"}"
+    local kr_path="/usr/share/keyrings/google-cloud-ops-agent.gpg"
     local REPO_NAME="google-cloud-ops-agent-${CODENAME}-${REPO_SUFFIX:-all}"
-    local REPO_DATA="deb https://${REPO_HOST}/apt ${REPO_NAME} main"
+    local REPO_DATA="deb [signed-by=${kr_path}] https://${REPO_HOST}/apt ${REPO_NAME} main"
     if ! cmp -s <<<"${REPO_DATA}" - /etc/apt/sources.list.d/google-cloud-ops-agent.list; then
       echo "Adding agent repository for ${ID}."
       ${DRY_RUN} tee <<<"${REPO_DATA}" /etc/apt/sources.list.d/google-cloud-ops-agent.list
       ${DRY_RUN} curl --connect-timeout 5 -s -f "https://${REPO_HOST}/apt/doc/apt-key.gpg" \
-        | ${DRY_RUN} apt-key add -
+        | ${DRY_RUN} gpg --dearmor -o "${kr_path}"
       CHANGED=1
     fi
   }


### PR DESCRIPTION
As requested in https://github.com/GoogleCloudPlatform/ops-agent/issues/1132

Thank you @sbconslt for hounding us to get it done.